### PR TITLE
Change SaveCommand's input

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -25,9 +25,9 @@ public class SaveCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Channels saving amount to wish."
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_SAVING + "SAVING_AMOUNT]\n"
+            + "[SAVING_AMOUNT]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_SAVING + "108.50";
+            + "108.50";
 
     public static final String MESSAGE_SAVE_SUCCESS = "Saved %1$s for wish %2$s%3$s.";
 

--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SAVING;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_WISHES;
 
 import java.util.List;

--- a/src/main/java/seedu/address/logic/parser/SaveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SaveCommandParser.java
@@ -27,23 +27,31 @@ public class SaveCommandParser implements Parser<SaveCommand> {
         ArgumentMultimap argumentMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_SAVING);
 
-        if (!isSavingsCommandPresent(argumentMultimap) || argumentMultimap.getPreamble().isEmpty()) {
+        // new
+
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SaveCommand.MESSAGE_USAGE));
         }
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(argumentMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SaveCommand.MESSAGE_USAGE), pe);
+
+        String[] arguments = trimmedArgs.split(" ");
+
+        if (arguments.length != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SaveCommand.MESSAGE_USAGE));
         }
 
-        String savedAmountString = argumentMultimap.getValue(PREFIX_SAVING).orElse("");
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(arguments[0]);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SaveCommand.MESSAGE_USAGE));
+        }
 
         Amount amount;
         try {
-            amount = new Amount(savedAmountString);
+            amount = new Amount(arguments[1]);
         } catch (IllegalArgumentException iae) {
-            throw new ParseException(String.format(MESSAGE_INVALID_AMOUNT, savedAmountString));
+            throw new ParseException(String.format(MESSAGE_INVALID_AMOUNT, arguments[1]));
         }
 
         return new SaveCommand(index, amount);

--- a/src/test/java/seedu/address/logic/parser/SaveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SaveCommandParserTest.java
@@ -21,8 +21,7 @@ public class SaveCommandParserTest {
 
     @Test
     public void parse_indexSpecified_success() {
-        final String userInput = targetIndex.getOneBased() + " " + PREFIX_SAVING
-                + VALID_SAVED_AMOUNT_AMY;
+        final String userInput = targetIndex.getOneBased() + " " + VALID_SAVED_AMOUNT_AMY;
 
         final SaveCommand expectedCommand = new SaveCommand(targetIndex, amount);
 
@@ -33,12 +32,8 @@ public class SaveCommandParserTest {
     public void parse_missingCompulsoryField_failure() {
         final String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE);
 
-        final String userInputMissingIndex = PREFIX_SAVING + VALID_SAVED_AMOUNT_AMY;
+        final String userInputMissingIndex = VALID_SAVED_AMOUNT_AMY;
         assertParseFailure(saveCommandParser, userInputMissingIndex,
-                expectedMessage);
-
-        final String userInputMissingSavingPrefix = targetIndex + " " + VALID_SAVED_AMOUNT_AMY;
-        assertParseFailure(saveCommandParser, userInputMissingSavingPrefix,
                 expectedMessage);
 
         final String userInputMissingSavingAmount = targetIndex + " " + PREFIX_SAVING;

--- a/src/test/java/seedu/address/logic/parser/WishBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/WishBookParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.REMARK_DESC_SAMPLE_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SAVED_AMOUNT_AMY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SAVING;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_WISH;
 
 import java.util.Arrays;

--- a/src/test/java/seedu/address/logic/parser/WishBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/WishBookParserTest.java
@@ -246,7 +246,7 @@ public class WishBookParserTest {
         Amount amount = new Amount(VALID_SAVED_AMOUNT_AMY);
         SaveCommand saveCommandFromParser = (SaveCommand) parser.parseCommand(
                 SaveCommand.COMMAND_WORD + " " + INDEX_FIRST_WISH.getOneBased() + " "
-            + PREFIX_SAVING + VALID_SAVED_AMOUNT_AMY);
+                        + VALID_SAVED_AMOUNT_AMY);
         assertEquals(new SaveCommand(INDEX_FIRST_WISH, amount), saveCommandFromParser);
     }
 


### PR DESCRIPTION
Removed prefix `s/` in SaveCommand's syntax.
Before:
save <index> s/<saveAmount>

After:
save <index> <saveAmount>