### PR TITLE
Change Amount methods to use Double values directly

### DIFF
--- a/src/main/java/seedu/address/commons/core/amount/Amount.java
+++ b/src/main/java/seedu/address/commons/core/amount/Amount.java
@@ -25,6 +25,14 @@ public class Amount {
     }
 
     /**
+     * Private constructor that takes in a {@code Double} value.
+     * @param value a {@code Double} value.
+     */
+    private Amount(Double value) {
+        this.value = value;
+    }
+
+    /**
      * Returns true if a given string is a valid Amount.
      *
      * @param possibleAmount A possibly valid Amount as a {@code String}
@@ -39,18 +47,18 @@ public class Amount {
     public static Amount add(Amount a1, Amount a2) {
         requireNonNull(a1);
         requireNonNull(a2);
-        return new Amount(Double.toString(a1.value + a2.value));
+        return new Amount(a1.value + a2.value);
     }
 
     /**
      * Returns an absolute, non-negative Amount.
      */
     public Amount getAbsoluteAmount() {
-        return new Amount(Double.toString(Math.abs(value)));
+        return new Amount(Math.abs(value));
     }
 
     public Amount getNegatedAmount() {
-        return new Amount(Double.toString(-this.value));
+        return new Amount(-this.value);
     }
 
     @Override


### PR DESCRIPTION
Previously, Amount methods used to convert Double values into String and then back into Double, which is redundant and introduced unpredictable errors, especially when executing Save commands. This back-and-forth conversion might have affected the precision of certain Double values, so a Double value converted to a String and then back to a Double might not be the exact same number.

Hence, the Amount class was slightly reworked to have a private constructor that takes in a Double value, and the methods were also changed to use this new constructor.

Moving forward, we should **avoid converting a Double value to a String and back to a Double**.